### PR TITLE
Add dynamic site URL detection

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_SITE_URL=https://www.bvslab.com/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ This project is built with:
 
 Simply open [Lovable](https://lovable.dev/projects/1bc2a5b4-4003-4324-9736-64f5cf1048f9) and click on Share -> Publish.
 
+### Configure the base URL
+
+The application detects the correct URL automatically. During development it uses `window.location.origin`. When building for production the URL defaults to `https://www.bvslab.com/`. You can override this by setting the `VITE_SITE_URL` environment variable.
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,15 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Biomedica from "./pages/Biomedica";
+import { getSiteUrl } from "./lib/siteUrl";
 
 const queryClient = new QueryClient();
 
 const App = () => {
-  // basename condicional basado en el entorno
-  const basename = import.meta.env.PROD ? '/app-react' : '/';
+  // La aplicación siempre vive en la raíz. El dominio varía según el entorno.
+  const basename = "/";
+  const siteUrl = getSiteUrl();
+  console.log("Base URL:", siteUrl);
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>

--- a/src/lib/siteUrl.ts
+++ b/src/lib/siteUrl.ts
@@ -1,0 +1,10 @@
+export function getSiteUrl(): string {
+  const envUrl = import.meta.env.VITE_SITE_URL as string | undefined;
+  if (envUrl && envUrl.length > 0) {
+    return envUrl.endsWith('/') ? envUrl : envUrl + '/';
+  }
+  if (import.meta.env.PROD) {
+    return 'https://www.bvslab.com/';
+  }
+  return window.location.origin + '/';
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
+const SITE_URL = process.env.VITE_SITE_URL || "https://www.bvslab.com/";
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   server: {
@@ -20,9 +22,10 @@ export default defineConfig(({ mode }) => ({
     },
   },
   // Para los assets (CSS, JS, imágenes)
-  base: mode === 'production' ? '/gitTres/dist/' : '/',
+  base: '/',
   // Variables de entorno personalizadas
   define: {
-    __APP_BASENAME__: mode === 'production' ? '"/app-react"' : '"/"'
+    __APP_BASENAME__: '"/"',
+    __SITE_URL__: mode === 'production' ? `"${SITE_URL}"` : '""'
   }
 }));


### PR DESCRIPTION
## Summary
- configure `vite.config.ts` to set `SITE_URL` and root base path
- add `getSiteUrl` helper to compute correct domain
- log site URL in `App.tsx`
- document how to configure the base URL in `README`
- include `.env.production` with default production domain

## Testing
- `npm run lint` *(fails: react-refresh, no-empty-object-type)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885ae4369b08323a0ecc6e528b9c73c