### PR TITLE
Usar imágenes remotas de Unsplash para catálogos

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,21 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## ¿Cómo genera Codex las capturas y por qué pueden verse como 404?
+
+- Cuando Codex comparte capturas dentro de la conversación, los archivos se guardan como artefactos temporales del entorno donde se ejecutó la tarea. Esos enlaces dejan de existir al finalizar la sesión, por lo que muestran `404` si intentas abrirlos más tarde.
+- No depende de que el proyecto tenga un dominio público en GitHub Pages; las capturas se generan a partir de un servidor de desarrollo local que se levanta con `npm run dev` dentro del contenedor.
+- El flujo es: iniciar el servidor (`npm run dev -- --host 0.0.0.0 --port 4173`), abrir esa URL local con Playwright/Chromium y guardar la imagen con un viewport fijo (por ejemplo, 1280×800). Después se adjunta el archivo resultante a la respuesta.
+- Si necesitas conservar las capturas, descárgalas antes de que termine la sesión o inclúyelas en el repositorio (por ejemplo, en `public/screenshots/`) para que queden versionadas.
+
+### Generar tus propias capturas
+
+```bash
+npm install
+npm run dev -- --host 0.0.0.0 --port 4173
+# En otra terminal (por ejemplo con Playwright):
+npx playwright screenshot http://127.0.0.1:4173/equipos equipos.png --width=1280 --height=800
+```
+
+También puedes abrir la URL en tu navegador local y capturar manualmente la pantalla.

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "globals": "^15.9.0",
         "lovable-tagger": "^1.1.7",
         "postcss": "^8.4.47",
+        "sharp": "^0.34.4",
         "tailwindcss": "^3.4.11",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
@@ -150,6 +151,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -807,6 +819,456 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.4.tgz",
+      "integrity": "sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.4.tgz",
+      "integrity": "sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.3.tgz",
+      "integrity": "sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.3.tgz",
+      "integrity": "sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.3.tgz",
+      "integrity": "sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.3.tgz",
+      "integrity": "sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.3.tgz",
+      "integrity": "sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.3.tgz",
+      "integrity": "sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.3.tgz",
+      "integrity": "sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.4.tgz",
+      "integrity": "sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.4.tgz",
+      "integrity": "sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.4.tgz",
+      "integrity": "sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.4.tgz",
+      "integrity": "sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.4.tgz",
+      "integrity": "sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.4.tgz",
+      "integrity": "sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.4.tgz",
+      "integrity": "sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.4.tgz",
+      "integrity": "sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.5.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.4.tgz",
+      "integrity": "sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.4.tgz",
+      "integrity": "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.4.tgz",
+      "integrity": "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -4120,6 +4582,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -6367,9 +6839,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6377,6 +6849,49 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.4.tgz",
+      "integrity": "sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.0",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.4",
+        "@img/sharp-darwin-x64": "0.34.4",
+        "@img/sharp-libvips-darwin-arm64": "1.2.3",
+        "@img/sharp-libvips-darwin-x64": "1.2.3",
+        "@img/sharp-libvips-linux-arm": "1.2.3",
+        "@img/sharp-libvips-linux-arm64": "1.2.3",
+        "@img/sharp-libvips-linux-ppc64": "1.2.3",
+        "@img/sharp-libvips-linux-s390x": "1.2.3",
+        "@img/sharp-libvips-linux-x64": "1.2.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.3",
+        "@img/sharp-linux-arm": "0.34.4",
+        "@img/sharp-linux-arm64": "0.34.4",
+        "@img/sharp-linux-ppc64": "0.34.4",
+        "@img/sharp-linux-s390x": "0.34.4",
+        "@img/sharp-linux-x64": "0.34.4",
+        "@img/sharp-linuxmusl-arm64": "0.34.4",
+        "@img/sharp-linuxmusl-x64": "0.34.4",
+        "@img/sharp-wasm32": "0.34.4",
+        "@img/sharp-win32-arm64": "0.34.4",
+        "@img/sharp-win32-ia32": "0.34.4",
+        "@img/sharp-win32-x64": "0.34.4"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "generate:placeholders": "node scripts/generate-placeholders.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -76,6 +77,7 @@
     "globals": "^15.9.0",
     "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
+    "sharp": "^0.34.4",
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",

--- a/scripts/generate-placeholders.mjs
+++ b/scripts/generate-placeholders.mjs
@@ -1,0 +1,122 @@
+import sharp from 'sharp';
+
+const images = [
+  {
+    basePath: 'public/assets/agronica/drone-field',
+    palette: ['#064e3b', '#0f766e', '#22c55e'],
+  },
+  {
+    basePath: 'public/assets/agronica/smart-irrigation',
+    palette: ['#1e3a8a', '#2563eb', '#38bdf8'],
+  },
+  {
+    basePath: 'public/assets/agronica/greenhouse-monitoring',
+    palette: ['#0f172a', '#1f2937', '#22d3ee'],
+  },
+  {
+    basePath: 'public/assets/automatica/robotic-arm',
+    palette: ['#111827', '#1f2937', '#f97316'],
+  },
+  {
+    basePath: 'public/assets/automatica/control-room',
+    palette: ['#0f172a', '#1e293b', '#60a5fa'],
+  },
+  {
+    basePath: 'public/assets/automatica/plc-panel',
+    palette: ['#020617', '#0f172a', '#22d3ee'],
+  },
+  {
+    basePath: 'public/assets/biomedica/mri-suite',
+    palette: ['#0b1120', '#1d4ed8', '#93c5fd'],
+  },
+  {
+    basePath: 'public/assets/biomedica/biolab-team',
+    palette: ['#0f172a', '#64748b', '#cbd5f5'],
+  },
+  {
+    basePath: 'public/assets/biomedica/surgery-monitor',
+    palette: ['#111827', '#1e40af', '#38bdf8'],
+  },
+  {
+    basePath: 'public/assets/equipos/estacion-laser-oftalmica',
+    palette: ['#082f49', '#0ea5e9', '#38bdf8'],
+  },
+  {
+    basePath: 'public/assets/equipos/camilla-motorizada',
+    palette: ['#1f2937', '#4b5563', '#a855f7'],
+  },
+  {
+    basePath: 'public/assets/equipos/estacion-calibracion',
+    palette: ['#111827', '#374151', '#facc15'],
+  },
+  {
+    basePath: 'public/assets/equipos/torre-endoscopia',
+    palette: ['#172554', '#1d4ed8', '#22d3ee'],
+  },
+  {
+    basePath: 'public/assets/equipos/panel-diagnostico',
+    palette: ['#0f172a', '#1e293b', '#6ee7b7'],
+  },
+  {
+    basePath: 'public/assets/equipos/sistema-anestesia',
+    palette: ['#0b1120', '#312e81', '#a855f7'],
+  },
+];
+
+async function createLayer(width, height, color) {
+  return sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: color,
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+async function generateImage(basePath, palette, width, height) {
+  const [primary, secondary, accent] = palette;
+  const diagonal = await createLayer(width, height, accent + 'cc');
+  const topLayer = await createLayer(width, Math.floor(height * 0.55), secondary + 'dd');
+
+  return sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: primary,
+    },
+  })
+    .composite([
+      {
+        input: topLayer,
+        top: 0,
+        left: 0,
+      },
+      {
+        input: diagonal,
+        top: 0,
+        left: 0,
+        blend: 'screen',
+      },
+    ])
+    .webp({ quality: 82 })
+    .toFile(`${basePath}-${width}.webp`);
+}
+
+async function run() {
+  await Promise.all(
+    images.flatMap(({ basePath, palette }) => [
+      generateImage(basePath, palette, 1280, 800),
+      generateImage(basePath, palette, 640, 400),
+    ])
+  );
+  console.log('Placeholder images generated.');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Agronica.tsx
+++ b/src/pages/Agronica.tsx
@@ -22,6 +22,14 @@ interface ServiceCardProps {
   desc: string;
 }
 
+interface GalleryImage {
+  srcSet: string;
+  fallback: string;
+  alt: string;
+  caption: string;
+  type?: string;
+}
+
 const infoCardsData: InfoCardProps[] = [
   { icon: Microscope, title: 'Diagnóstico', desc: 'Sensores y equipos de precisión agrícola.', delay: 'delay-100', extraTitle: 'MÁS DETALLE' },
   { icon: Tractor, title: 'Tratamiento', desc: 'Maquinaria y procesos de optimización.', delay: 'delay-200', extraTitle: 'VER EQUIPOS' },
@@ -36,6 +44,36 @@ const servicesData: ServiceCardProps[] = [
   { icon: Briefcase, title: 'Asesorías', desc: 'Consultoría técnica en agrotecnología.' },
   { icon: Combine, title: 'Ventas de Equipo', desc: 'Maquinaria y drones de última generación.' },
   { icon: ShieldCheck, title: 'Certificación', desc: 'Cumplimiento de normas de agricultura sostenible.' }
+];
+
+const agronicaGallery: GalleryImage[] = [
+  {
+    fallback:
+      'https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3',
+    srcSet:
+      'https://images.unsplash.com/photo-1501004318641-b39e6451bec6?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1501004318641-b39e6451bec6?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w',
+    type: 'image/webp',
+    alt: 'Dron agrícola sobrevolando cultivo',
+    caption: 'Monitoreo de cultivos con drones y visión multiespectral.',
+  },
+  {
+    fallback:
+      'https://images.unsplash.com/photo-1500937386664-56aa98c98e23?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3',
+    srcSet:
+      'https://images.unsplash.com/photo-1500937386664-56aa98c98e23?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1500937386664-56aa98c98e23?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w',
+    type: 'image/webp',
+    alt: 'Sistema de riego inteligente',
+    caption: 'Riego inteligente con control de caudal en tiempo real.',
+  },
+  {
+    fallback:
+      'https://images.unsplash.com/photo-1524592094714-0f0654e20314?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3',
+    srcSet:
+      'https://images.unsplash.com/photo-1524592094714-0f0654e20314?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1524592094714-0f0654e20314?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w',
+    type: 'image/webp',
+    alt: 'Invernadero monitorizado digitalmente',
+    caption: 'Invernaderos conectados con sensores de clima y nutrientes.',
+  },
 ];
 
 const Agronica = () => {
@@ -86,7 +124,10 @@ const Agronica = () => {
             <p className="text-xl text-green-100 mb-8 max-w-4xl mx-auto">
               Tecnologías para potenciar la agricultura con innovación mecánica y sostenibilidad.
             </p>
-            <Button size="lg" className="bg-green-600 hover:bg-green-700 text-white text-lg px-8 py-6">
+            <Button
+              size="lg"
+              className="bg-green-600 text-white text-lg px-8 py-6 transition-colors duration-200 hover:bg-green-700 focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2"
+            >
               Solicitar Consulta Técnica
             </Button>
           </div>
@@ -102,7 +143,7 @@ const Agronica = () => {
               <div className="w-24 h-1 bg-green-600 mx-auto"></div>
             </div>
 
-            <div className="grid md:grid-cols-2 gap-12 items-center">
+            <div className="grid md:grid-cols-2 gap-12 items-start">
               <div className="space-y-6 text-lg text-green-700 leading-relaxed">
                 <p>
                   Las tecnologías agrónicas son fundamentales para un sistema productivo sostenible. Los dispositivos de precisión y maquinaria avanzada son cruciales para la prevención de plagas, el diagnóstico de cultivos, el tratamiento de suelos y la rehabilitación de ecosistemas agrícolas.
@@ -120,22 +161,46 @@ const Agronica = () => {
                 </div>
               </div>
               
-              <div ref={cardsRef} className="grid grid-cols-2 gap-4">
-                {infoCardsData.map(({ icon: Icon, title, desc, delay, extraTitle }, index) => (
-                  <Card 
-                    key={title} 
-                    className={`relative group text-center overflow-visible transition-all duration-700 ease-out ${delay} ${isCardsVisible ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'} hover:shadow-green-600/20 hover:shadow-lg hover:-translate-y-2 border-green-200`}
-                  >
-                    <div className={`absolute left-0 right-0 py-2 px-3 bg-green-700 text-white shadow-lg z-10 transform transition-all duration-300 ease-out opacity-0 scale-95 group-hover:opacity-100 group-hover:scale-100 ${index < 2 ? 'bottom-full rounded-t-lg' : 'top-full rounded-b-lg'}`}>
-                      <h5 className="font-bold uppercase text-xs tracking-wider">{extraTitle}</h5>
-                    </div>
-                    <CardContent className="pt-6">
-                      <Icon className="w-12 h-12 text-green-600 mx-auto mb-3" />
-                      <h4 className="font-semibold text-green-800 mb-2">{title}</h4>
-                      <p className="text-sm text-green-600">{desc}</p>
-                    </CardContent>
-                  </Card>
-                ))}
+              <div className="space-y-6">
+                <div className="grid sm:grid-cols-2 gap-6">
+                  {agronicaGallery.map(({ alt, caption, fallback, srcSet, type }) => (
+                    <figure
+                      key={alt}
+                      className="relative overflow-hidden rounded-xl shadow-lg transition-transform duration-300 ease-out hover:-translate-y-1 hover:shadow-2xl"
+                    >
+                      <picture>
+                        <source srcSet={srcSet} type={type ?? 'image/webp'} sizes="(min-width: 768px) 50vw, 100vw" />
+                        <img
+                          src={fallback}
+                          alt={alt}
+                          loading="lazy"
+                          decoding="async"
+                          className="w-full h-48 object-cover"
+                        />
+                      </picture>
+                      <figcaption className="absolute inset-x-0 bottom-0 bg-green-950/70 text-green-100 text-sm px-3 py-2">
+                        {caption}
+                      </figcaption>
+                    </figure>
+                  ))}
+                </div>
+                <div ref={cardsRef} className="grid grid-cols-2 gap-4">
+                  {infoCardsData.map(({ icon: Icon, title, desc, delay, extraTitle }, index) => (
+                    <Card
+                      key={title}
+                      className={`relative group text-center overflow-visible transition-all duration-700 ease-out ${delay} ${isCardsVisible ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'} hover:shadow-green-600/20 hover:shadow-lg hover:-translate-y-2 border-green-200`}
+                    >
+                      <div className={`absolute left-0 right-0 py-2 px-3 bg-green-700 text-white shadow-lg z-10 transform transition-all duration-300 ease-out opacity-0 scale-95 group-hover:opacity-100 group-hover:scale-100 ${index < 2 ? 'bottom-full rounded-t-lg' : 'top-full rounded-b-lg'}`}>
+                        <h5 className="font-bold uppercase text-xs tracking-wider">{extraTitle}</h5>
+                      </div>
+                      <CardContent className="pt-6">
+                        <Icon className="w-12 h-12 text-green-600 mx-auto mb-3" />
+                        <h4 className="font-semibold text-green-800 mb-2">{title}</h4>
+                        <p className="text-sm text-green-600">{desc}</p>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
               </div>
             </div>
           </div>
@@ -239,10 +304,18 @@ const Agronica = () => {
                     Contamos con la experiencia y la tecnología para llevar su operación al siguiente nivel.
                 </p>
                 <div className="space-x-4">
-                    <Button variant="secondary" size="lg" className="bg-white text-green-700 hover:bg-green-50">
+                    <Button
+                      variant="secondary"
+                      size="lg"
+                      className="bg-white text-green-700 transition-colors duration-200 hover:bg-green-200 hover:text-green-900 focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2"
+                    >
                         Ver Casos de Éxito
                     </Button>
-                    <Button variant="outline" size="lg" className="border-white text-white hover:bg-white hover:text-green-700">
+                    <Button
+                      variant="outline"
+                      size="lg"
+                      className="border-white text-white transition-colors duration-200 hover:bg-white hover:text-green-700 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2"
+                    >
                         Solicitar Cotización
                     </Button>
                 </div>

--- a/src/pages/Automatica.tsx
+++ b/src/pages/Automatica.tsx
@@ -13,6 +13,44 @@ const diagnosticCards = [
   { icon: Zap, title: 'Control', desc: 'Automatización total', delay: 'delay-[550ms]', extraTitle: 'CONOCER MÁS', extraDesc: 'Sistemas de control y supervisión SCADA avanzados.' }
 ];
 
+interface GalleryImage {
+  srcSet: string;
+  fallback: string;
+  alt: string;
+  caption: string;
+  type?: string;
+}
+
+const automationGallery: GalleryImage[] = [
+  {
+    fallback:
+      'https://images.unsplash.com/photo-1581092334520-58f7996c9f66?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3',
+    srcSet:
+      'https://images.unsplash.com/photo-1581092334520-58f7996c9f66?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1581092334520-58f7996c9f66?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w',
+    type: 'image/webp',
+    alt: 'Brazo robótico ensamblando componentes',
+    caption: 'Robots colaborativos para líneas de producción flexibles.',
+  },
+  {
+    fallback:
+      'https://images.unsplash.com/photo-1581090700227-1e37b190418e?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3',
+    srcSet:
+      'https://images.unsplash.com/photo-1581090700227-1e37b190418e?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1581090700227-1e37b190418e?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w',
+    type: 'image/webp',
+    alt: 'Sala de control industrial con paneles digitales',
+    caption: 'Centros de control integrados con analítica en tiempo real.',
+  },
+  {
+    fallback:
+      'https://images.unsplash.com/photo-1581090467325-0f06c81f2d39?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3',
+    srcSet:
+      'https://images.unsplash.com/photo-1581090467325-0f06c81f2d39?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1581090467325-0f06c81f2d39?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w',
+    type: 'image/webp',
+    alt: 'Panel PLC con cableado estructurado',
+    caption: 'Gabinetes PLC diseñados para mantenimiento predictivo.',
+  },
+];
+
 const Automatica = () => {
   const [isCardsVisible, setIsCardsVisible] = useState(false);
   const cardsRef = useRef(null);
@@ -65,7 +103,10 @@ const Automatica = () => {
             Tecnologías de automatización fundamentales para sistemas industriales eficientes. 
             Especialistas en herramientas mecánicas y control de procesos automatizados.
           </p>
-          <Button size="lg" className="bg-yellow-500 text-black hover:bg-yellow-400 font-semibold">
+          <Button
+            size="lg"
+            className="bg-yellow-500 text-black font-semibold transition-colors duration-200 hover:bg-yellow-400 focus-visible:ring-2 focus-visible:ring-yellow-200 focus-visible:ring-offset-2"
+          >
             Solicitar Consulta Técnica
           </Button>
         </div>
@@ -81,7 +122,7 @@ const Automatica = () => {
             <div className="w-20 h-1 bg-yellow-500 mx-auto"></div>
           </div>
 
-          <div className="grid md:grid-cols-2 gap-12 items-center">
+          <div className="grid md:grid-cols-2 gap-12 items-start">
             <div>
               <p className="text-gray-600 mb-6 text-lg leading-relaxed">
                 Las tecnologías de automatización son fundamentales en un sistema industrial operativo. Las herramientas mecánicas automatizadas son cruciales para la optimización, el control, el diagnóstico y el mantenimiento de procesos industriales.
@@ -99,37 +140,60 @@ const Automatica = () => {
               </div>
             </div>
             
-            <div ref={cardsRef} className="grid grid-cols-2 gap-4">
-              {diagnosticCards.map(({ icon: Icon, title, desc, delay, extraTitle, extraDesc }, index) => (
-                <Card 
-                  key={title} 
-                  className={`
+            <div className="space-y-6">
+              <div className="grid sm:grid-cols-2 gap-6">
+                {automationGallery.map(({ alt, caption, fallback, srcSet, type }) => (
+                  <figure
+                    key={alt}
+                    className="relative overflow-hidden rounded-xl shadow-lg transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-2xl"
+                  >
+                    <picture>
+                      <source srcSet={srcSet} type={type ?? 'image/webp'} sizes="(min-width: 768px) 50vw, 100vw" />
+                      <img
+                        src={fallback}
+                        alt={alt}
+                        loading="lazy"
+                        decoding="async"
+                        className="w-full h-48 object-cover"
+                      />
+                    </picture>
+                    <figcaption className="absolute inset-x-0 bottom-0 bg-slate-900/70 text-slate-50 text-xs px-3 py-2">
+                      {caption}
+                    </figcaption>
+                  </figure>
+                ))}
+              </div>
+              <div ref={cardsRef} className="grid grid-cols-2 gap-4">
+                {diagnosticCards.map(({ icon: Icon, title, desc, delay, extraTitle, extraDesc }, index) => (
+                  <Card
+                    key={title}
+                    className={`
                     relative group text-center overflow-visible
                     transition-all duration-700 ease-out ${delay}
                     ${isCardsVisible ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'}
                     hover:bg-yellow-100 border border-gray-200
                     ${index < 2 ? 'group-hover:rounded-t-none' : 'group-hover:rounded-b-none'}
                   `}
-                >
-                  {/* Pestaña de información extra en hover */}
-                  <div className={`
+                  >
+                    <div className={`
                     absolute left-0 right-0 py-2 px-3 bg-gray-800 text-white shadow-lg z-10
                     transform transition-all duration-300 ease-out
                     opacity-0 scale-95 group-hover:opacity-100 group-hover:scale-100
-                    ${index < 2 
-                      ? 'bottom-full rounded-t-lg' 
+                    ${index < 2
+                      ? 'bottom-full rounded-t-lg'
                       : 'top-full rounded-b-lg'
                     }
                   `}>
-                    <h5 className="font-bold uppercase text-xs tracking-wider">{extraTitle}</h5>
-                  </div>
-                  <CardContent className="pt-6">
-                    <Icon className="w-12 h-12 text-yellow-500 mx-auto mb-3" />
-                    <h4 className="font-semibold text-gray-800 mb-2">{title}</h4>
-                    <p className="text-sm text-gray-600">{desc}</p>
-                  </CardContent>
-                </Card>
-              ))}
+                      <h5 className="font-bold uppercase text-xs tracking-wider">{extraTitle}</h5>
+                    </div>
+                    <CardContent className="pt-6">
+                      <Icon className="w-12 h-12 text-yellow-500 mx-auto mb-3" />
+                      <h4 className="font-semibold text-gray-800 mb-2">{title}</h4>
+                      <p className="text-sm text-gray-600">{desc}</p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
             </div>
           </div>
         </div>
@@ -243,10 +307,17 @@ const Automatica = () => {
             Contamos con la experiencia y certificaciones necesarias para garantizar el óptimo funcionamiento de sus sistemas automatizados
           </p>
           <div className="space-x-4">
-            <Button variant="outline" size="lg" className="bg-white text-black hover:bg-gray-100 border-gray-300">
+            <Button
+              variant="outline"
+              size="lg"
+              className="bg-white text-black border-gray-300 transition-colors duration-200 hover:bg-gray-200 focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-2"
+            >
               Ver Casos de Estudio
             </Button>
-            <Button size="lg" className="bg-orange-500 text-white hover:bg-orange-600">
+            <Button
+              size="lg"
+              className="bg-orange-500 text-white transition-colors duration-200 hover:bg-orange-600 focus-visible:ring-2 focus-visible:ring-orange-200 focus-visible:ring-offset-2"
+            >
               Solicitar Cotización
             </Button>
           </div>

--- a/src/pages/Biomedica.tsx
+++ b/src/pages/Biomedica.tsx
@@ -13,6 +13,44 @@ const diagnosticCards = [
   { icon: Zap, title: 'Rehabilitación', desc: 'Recuperación', delay: 'delay-[550ms]', extraTitle: 'CONOCER MÁS', extraDesc: 'Tecnología de apoyo para la recuperación funcional del paciente.' }
 ];
 
+interface GalleryImage {
+  srcSet: string;
+  fallback: string;
+  alt: string;
+  caption: string;
+  type?: string;
+}
+
+const biomedGallery: GalleryImage[] = [
+  {
+    fallback:
+      'https://images.unsplash.com/photo-1586773860418-d37222d8fce3?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3',
+    srcSet:
+      'https://images.unsplash.com/photo-1586773860418-d37222d8fce3?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1586773860418-d37222d8fce3?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w',
+    type: 'image/webp',
+    alt: 'Sala de resonancia magnética preparada',
+    caption: 'Salas de resonancia con monitoreo remoto y calibración continua.',
+  },
+  {
+    fallback:
+      'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3',
+    srcSet:
+      'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w',
+    type: 'image/webp',
+    alt: 'Equipo biomédico colaborando en laboratorio',
+    caption: 'Equipos multidisciplinarios coordinando mantenimiento clínico.',
+  },
+  {
+    fallback:
+      'https://images.unsplash.com/photo-1580281658629-6cb04f886040?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3',
+    srcSet:
+      'https://images.unsplash.com/photo-1580281658629-6cb04f886040?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1580281658629-6cb04f886040?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w',
+    type: 'image/webp',
+    alt: 'Monitores quirúrgicos sincronizados',
+    caption: 'Quirófanos digitales con sincronización de signos vitales.',
+  },
+];
+
 const Biomedica = () => {
   const [isCardsVisible, setIsCardsVisible] = useState(false);
   const cardsRef = useRef(null);
@@ -67,7 +105,10 @@ const Biomedica = () => {
             Tecnologías sanitarias fundamentales para sistemas de salud operativos. 
             Especialistas en dispositivos médicos para prevención, diagnóstico, tratamiento y rehabilitación.
           </p>
-          <Button size="lg" className="bg-primary text-primary-foreground hover:bg-trust-blue">
+          <Button
+            size="lg"
+            className="bg-primary text-primary-foreground transition-colors duration-200 hover:bg-trust-blue focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2"
+          >
             Solicitar Consulta Técnica
           </Button>
         </div>
@@ -83,7 +124,7 @@ const Biomedica = () => {
             <div className="w-20 h-1 bg-primary mx-auto"></div>
           </div>
 
-          <div className="grid md:grid-cols-2 gap-12 items-center">
+          <div className="grid md:grid-cols-2 gap-12 items-start">
             <div>
               <p className="text-tech-gray mb-6 text-lg leading-relaxed">
                 Las tecnologías sanitarias son fundamentales en un sistema de salud operativo. Los dispositivos médicos son cruciales para la prevención, el diagnóstico, el tratamiento y la rehabilitación de enfermedades.
@@ -101,37 +142,60 @@ const Biomedica = () => {
               </div>
             </div>
             
-            <div ref={cardsRef} className="grid grid-cols-2 gap-4">
-              {diagnosticCards.map(({ icon: Icon, title, desc, delay, extraTitle, extraDesc }, index) => (
-                <Card 
-                  key={title} 
-                  className={`
+            <div className="space-y-6">
+              <div className="grid sm:grid-cols-2 gap-6">
+                {biomedGallery.map(({ alt, caption, fallback, srcSet, type }) => (
+                  <figure
+                    key={alt}
+                    className="relative overflow-hidden rounded-xl shadow-lg transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-2xl"
+                  >
+                    <picture>
+                      <source srcSet={srcSet} type={type ?? 'image/webp'} sizes="(min-width: 768px) 50vw, 100vw" />
+                      <img
+                        src={fallback}
+                        alt={alt}
+                        loading="lazy"
+                        decoding="async"
+                        className="w-full h-48 object-cover"
+                      />
+                    </picture>
+                    <figcaption className="absolute inset-x-0 bottom-0 bg-foreground/70 text-primary-foreground text-xs px-3 py-2">
+                      {caption}
+                    </figcaption>
+                  </figure>
+                ))}
+              </div>
+              <div ref={cardsRef} className="grid grid-cols-2 gap-4">
+                {diagnosticCards.map(({ icon: Icon, title, desc, delay, extraTitle, extraDesc }, index) => (
+                  <Card
+                    key={title}
+                    className={`
                     relative group text-center overflow-visible
                     transition-all duration-700 ease-out ${delay}
                     ${isCardsVisible ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'}
                     hover:bg-blue-200
                     ${index < 2 ? 'group-hover:rounded-t-none' : 'group-hover:rounded-b-none'}
                   `}
-                >
-                  {/* Pestaña de información extra en hover */}
-                  <div className={`
+                  >
+                    <div className={`
                     absolute left-0 right-0 py-2 px-3 bg-foreground text-primary-foreground shadow-lg z-10
                     transform transition-all duration-300 ease-out
                     opacity-0 scale-95 group-hover:opacity-100 group-hover:scale-100
-                    ${index < 2 
-                      ? 'bottom-full rounded-t-lg' 
+                    ${index < 2
+                      ? 'bottom-full rounded-t-lg'
                       : 'top-full rounded-b-lg'
                     }
                   `}>
-                    <h5 className="font-bold uppercase text-xs tracking-wider">{extraTitle}</h5>
-                  </div>
-                  <CardContent className="pt-6">
-                    <Icon className="w-12 h-12 text-primary mx-auto mb-3" />
-                    <h4 className="font-semibold text-card-foreground mb-2">{title}</h4>
-                    <p className="text-sm text-tech-gray">{desc}</p>
-                  </CardContent>
-                </Card>
-              ))}
+                      <h5 className="font-bold uppercase text-xs tracking-wider">{extraTitle}</h5>
+                    </div>
+                    <CardContent className="pt-6">
+                      <Icon className="w-12 h-12 text-primary mx-auto mb-3" />
+                      <h4 className="font-semibold text-card-foreground mb-2">{title}</h4>
+                      <p className="text-sm text-tech-gray">{desc}</p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
             </div>
           </div>
         </div>
@@ -245,10 +309,18 @@ const Biomedica = () => {
             Contamos con la experiencia y certificaciones necesarias para garantizar el óptimo funcionamiento de sus equipos médicos
           </p>
           <div className="space-x-4">
-            <Button variant="outline" size="lg" className="bg-white text-primary hover:bg-gray-100">
+            <Button
+              variant="outline"
+              size="lg"
+              className="bg-white text-primary transition-colors duration-200 hover:bg-gray-200 focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2"
+            >
               Ver Casos de Estudio
             </Button>
-            <Button variant="outline" size="lg" className="bg-accent text-accent-foreground hover:bg-trust-blue">
+            <Button
+              variant="outline"
+              size="lg"
+              className="bg-accent text-accent-foreground transition-colors duration-200 hover:bg-accent/90 focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2"
+            >
               Solicitar Cotización
             </Button>
           </div>

--- a/src/pages/Equipos.tsx
+++ b/src/pages/Equipos.tsx
@@ -5,13 +5,20 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ShoppingCart, Plus, Minus, Trash2, Eye, Zap, Cog, Microscope, MessageCircle } from "lucide-react";
+import { cn } from '@/lib/utils';
+
+interface ProductImage {
+  fallback: string;
+  srcSet?: string;
+  type?: string;
+}
 
 interface Product {
   id: number;
   name: string;
   category: string;
   price: number;
-  image: string;
+  image: ProductImage;
   description: string;
 }
 
@@ -21,27 +28,231 @@ interface CartItem extends Product {
 
 const products: Product[] = [
   // Mechanized
-  { id: 1, name: "Montura Mecánica de Precisión", category: "mechanized", price: 250000, image: "https://images.unsplash.com/photo-1581094794329-c8112a89af12?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3", description: "Montura ajustable para equipos ópticos" },
-  { id: 2, name: "Engranajes de Alta Precisión", category: "mechanized", price: 180000, image: "https://images.unsplash.com/photo-1542376770-6b9a3b176b63?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=3b9c3f2f3e7f4b1ad8e2d6b9a1c2b3d4", description: "Engranajes para sistemas láser" },
-  { id: 3, name: "Brazo Articulado Mecánico", category: "mechanized", price: 320000, image: "https://images.unsplash.com/photo-1581094644950-6f5d1b1f1c6f?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=9c3e4d2a6b7e1d8f2c4b5a6d7e8f9a0b", description: "Brazo para posicionamiento de equipos" },
+  {
+    id: 1,
+    name: "Montura Mecánica de Precisión",
+    category: "mechanized",
+    price: 250000,
+    image: {
+      fallback: "https://images.unsplash.com/photo-1581094794329-c8112a89af12?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3",
+    },
+    description: "Montura ajustable para equipos ópticos.",
+  },
+  {
+    id: 2,
+    name: "Engranajes de Alta Precisión",
+    category: "mechanized",
+    price: 180000,
+    image: {
+      fallback: "https://images.unsplash.com/photo-1542376770-6b9a3b176b63?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3",
+    },
+    description: "Engranajes para sistemas láser.",
+  },
+  {
+    id: 3,
+    name: "Brazo Articulado Mecánico",
+    category: "mechanized",
+    price: 320000,
+    image: {
+      fallback: "https://images.unsplash.com/photo-1581094800484-0ce28b04e036?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3",
+    },
+    description: "Brazo modular para posicionamiento de equipos.",
+  },
+  {
+    id: 15,
+    name: "Camilla Quirúrgica Motorizada",
+    category: "mechanized",
+    price: 2250000,
+    image: {
+      fallback:
+        "https://images.unsplash.com/photo-1580281657521-84a1c7c3c924?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3",
+      srcSet:
+        "https://images.unsplash.com/photo-1580281657521-84a1c7c3c924?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1580281657521-84a1c7c3c924?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w",
+      type: "image/webp",
+    },
+    description: "Camilla con posicionamiento eléctrico y memoria de posturas.",
+  },
 
   // Electronic
-  { id: 4, name: "Controlador Electrónico Láser", category: "electronic", price: 450000, image: "https://images.unsplash.com/photo-1518770660439-4636190af475?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=a1b2c3d4e5f67890123456789abcdef0", description: "Controlador para diodos láser" },
-  { id: 5, name: "Fuente de Alimentación Estabilizada", category: "electronic", price: 280000, image: "https://images.unsplash.com/photo-1605902711622-cfb43c44367e?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=4a5b6c7d8e9f0123456789abcdef0123", description: "Fuente para equipos médicos" },
-  { id: 6, name: "Módulo de Control Rayos X", category: "electronic", price: 550000, image: "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=abcdef1234567890abcdef1234567890", description: "Controlador para máquinas de rayos X" },
+  {
+    id: 4,
+    name: "Controlador Electrónico Láser",
+    category: "electronic",
+    price: 450000,
+    image: {
+      fallback: "https://images.unsplash.com/photo-1518770660439-4636190af475?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3",
+    },
+    description: "Controlador de precisión para diodos láser.",
+  },
+  {
+    id: 5,
+    name: "Fuente de Alimentación Estabilizada",
+    category: "electronic",
+    price: 280000,
+    image: {
+      fallback: "https://images.unsplash.com/photo-1605902711622-cfb43c44367e?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3",
+    },
+    description: "Fuente para equipos médicos sensibles.",
+  },
+  {
+    id: 6,
+    name: "Módulo de Control Rayos X",
+    category: "electronic",
+    price: 550000,
+    image: {
+      fallback: "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3",
+    },
+    description: "Controlador para máquinas de rayos X.",
+  },
+  {
+    id: 16,
+    name: "Estación de Calibración Integral",
+    category: "electronic",
+    price: 1420000,
+    image: {
+      fallback:
+        "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3",
+      srcSet:
+        "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w",
+      type: "image/webp",
+    },
+    description: "Banco modular con calibradores digitales y registro automático.",
+  },
+  {
+    id: 18,
+    name: "Panel de Diagnóstico Multiparámetro",
+    category: "electronic",
+    price: 990000,
+    image: {
+      fallback:
+        "https://images.unsplash.com/photo-1519494026892-80bbd2d6fd0d?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3",
+      srcSet:
+        "https://images.unsplash.com/photo-1519494026892-80bbd2d6fd0d?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1519494026892-80bbd2d6fd0d?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w",
+      type: "image/webp",
+    },
+    description: "Panel compacto con indicadores táctiles integrados.",
+  },
 
   // Optics
-  { id: 7, name: "Lentes Ópticas de Precisión", category: "optics", price: 150000, image: "https://images.unsplash.com/photo-1541534401786-5c6c6dcc0b7e?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=11223344556677889900aabbccddeeff", description: "Lentes para microscopios y equipos" },
-  { id: 8, name: "Espejos Reflectantes Láser", category: "optics", price: 200000, image: "https://images.unsplash.com/photo-1517694712202-14dd9538aa97?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=33445566778899aabbccddeeff001122", description: "Espejos para sistemas láser" },
-  { id: 9, name: "Prismas Ópticos", category: "optics", price: 120000, image: "https://images.unsplash.com/photo-1557804506-669a67965ba0?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3", description: "Prismas para equipos ópticos" },
+  {
+    id: 7,
+    name: "Lentes Ópticas de Precisión",
+    category: "optics",
+    price: 150000,
+    image: {
+      fallback: "https://images.unsplash.com/photo-1541534401786-5c6c6dcc0b7e?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3",
+    },
+    description: "Lentes para microscopios y sistemas ópticos.",
+  },
+  {
+    id: 8,
+    name: "Espejos Reflectantes Láser",
+    category: "optics",
+    price: 200000,
+    image: {
+      fallback: "https://images.unsplash.com/photo-1517694712202-14dd9538aa97?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3",
+    },
+    description: "Espejos dieléctricos para sistemas láser.",
+  },
+  {
+    id: 9,
+    name: "Prismas Ópticos",
+    category: "optics",
+    price: 120000,
+    image: {
+      fallback: "https://images.unsplash.com/photo-1557804506-669a67965ba0?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3",
+    },
+    description: "Prismas de alta dispersión para instrumentación.",
+  },
+  {
+    id: 14,
+    name: "Estación Láser Oftálmica",
+    category: "optics",
+    price: 1850000,
+    image: {
+      fallback:
+        "https://images.unsplash.com/photo-1580281658560-1cae9be7b61f?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3",
+      srcSet:
+        "https://images.unsplash.com/photo-1580281658560-1cae9be7b61f?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1580281658560-1cae9be7b61f?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w",
+      type: "image/webp",
+    },
+    description: "Sistema integral para alineación de láser oftálmico.",
+  },
 
   // Aesthetics (additional)
-  { id: 10, name: "Láser de Depilación", category: "aesthetics", price: 1200000, image: "https://images.unsplash.com/photo-1536305030012-6a1f4b6a5d2b?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=66778899aabbccddeeff001122334455", description: "Equipo láser para estética" },
-  { id: 11, name: "Máquina de Radiofrecuencia", category: "aesthetics", price: 800000, image: "https://images.unsplash.com/photo-1582719478147-5f5f5f5f5f5f?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=77889900aabbccddeeff001122334455", description: "Equipo de radiofrecuencia estética" },
+  {
+    id: 10,
+    name: "Láser de Depilación",
+    category: "aesthetics",
+    price: 1200000,
+    image: {
+      fallback: "https://images.unsplash.com/photo-1536305030012-6a1f4b6a5d2b?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3",
+    },
+    description: "Equipo láser para estética profesional.",
+  },
+  {
+    id: 11,
+    name: "Máquina de Radiofrecuencia",
+    category: "aesthetics",
+    price: 800000,
+    image: {
+      fallback:
+        "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80&ixlib=rb-4.0.3",
+    },
+    description: "Equipo de radiofrecuencia para tratamientos dérmicos.",
+  },
+  {
+    id: 19,
+    name: "Sistema de Anestesia Inteligente",
+    category: "aesthetics",
+    price: 3120000,
+    image: {
+      fallback:
+        "https://images.unsplash.com/photo-1582719478147-5fd16926c8ff?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3",
+      srcSet:
+        "https://images.unsplash.com/photo-1582719478147-5fd16926c8ff?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1582719478147-5fd16926c8ff?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w",
+      type: "image/webp",
+    },
+    description: "Mezcla asistida de gases con alarmas redundantes.",
+  },
 
   // Ray Machines (additional)
-  { id: 12, name: "Generador de Rayos X", category: "ray-machines", price: 2500000, image: "https://images.unsplash.com/photo-1582719478147-8a8a8a8a8a8a?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=889900aabbccddeeff00112233445566", description: "Generador para equipos de rayos X" },
-  { id: 13, name: "Detector de Rayos X", category: "ray-machines", price: 900000, image: "https://images.unsplash.com/photo-1582719478147-9b9b9b9b9b9b?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=9900aabbccddeeff0011223344556677", description: "Detector digital para rayos X" },
+  {
+    id: 12,
+    name: "Generador de Rayos X",
+    category: "ray-machines",
+    price: 2500000,
+    image: {
+      fallback:
+        "https://images.unsplash.com/photo-1580281658301-4a8d0ebba9e0?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3",
+    },
+    description: "Generador de alto rendimiento para rayos X.",
+  },
+  {
+    id: 13,
+    name: "Detector de Rayos X",
+    category: "ray-machines",
+    price: 900000,
+    image: {
+      fallback:
+        "https://images.unsplash.com/photo-1582719478253-4e88f37e14b4?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3",
+    },
+    description: "Detector digital de alta sensibilidad.",
+  },
+  {
+    id: 17,
+    name: "Torre de Endoscopia Digital",
+    category: "ray-machines",
+    price: 2680000,
+    image: {
+      fallback:
+        "https://images.unsplash.com/photo-1580281658560-1cae9be7b61f?auto=format&fit=crop&w=960&q=80&ixlib=rb-4.0.3",
+      srcSet:
+        "https://images.unsplash.com/photo-1580281658560-1cae9be7b61f?fit=crop&w=640&q=80&fm=webp&ixlib=rb-4.0.3 640w, https://images.unsplash.com/photo-1580281658560-1cae9be7b61f?fit=crop&w=1280&q=80&fm=webp&ixlib=rb-4.0.3 1280w",
+      type: "image/webp",
+    },
+    description: "Plataforma 4K con captura y control de iluminación integrados.",
+  },
 ];
 
 const categories = [
@@ -57,26 +268,27 @@ const Equipos = () => {
   const [cart, setCart] = useState<CartItem[]>([]);
   const [selectedCategory, setSelectedCategory] = useState('all');
 
-  const filteredProducts = selectedCategory === 'all' ? products : products.filter(p => p.category === selectedCategory);
+  const filteredProducts =
+    selectedCategory === 'all' ? products : products.filter((p) => p.category === selectedCategory);
 
   const addToCart = (product: Product) => {
-    setCart(prev => {
-      const existing = prev.find(item => item.id === product.id);
+    setCart((prev) => {
+      const existing = prev.find((item) => item.id === product.id);
       if (existing) {
-        return prev.map(item => item.id === product.id ? { ...item, quantity: item.quantity + 1 } : item);
+        return prev.map((item) => (item.id === product.id ? { ...item, quantity: item.quantity + 1 } : item));
       }
       return [...prev, { ...product, quantity: 1 }];
     });
   };
 
-  // Abre WhatsApp con un mensaje prellenado sobre el producto
   const enviarWhatsApp = (product: Product, numeroWhatsApp = "573134627810") => {
-    const mensaje = `🛒 *Solicitud de Información*\n\n` +
-                    `📦 *Producto:* ${product.name}\n` +
-                    `💰 *Precio:* $${product.price.toLocaleString()}\n` +
-                    `🏷️ *Categoría:* ${product.category}\n` +
-                    `📝 *Descripción:* ${product.description}\n\n` +
-                    `Me interesa este producto. ¿Podrían darme más información?`;
+    const mensaje =
+      `🛒 *Solicitud de Información*\n\n` +
+      `📦 *Producto:* ${product.name}\n` +
+      `💰 *Precio:* $${product.price.toLocaleString()}\n` +
+      `🏷️ *Categoría:* ${product.category}\n` +
+      `📝 *Descripción:* ${product.description}\n\n` +
+      `Me interesa este producto. ¿Podrían darme más información?`;
 
     const mensajeCodificado = encodeURIComponent(mensaje);
     const url = `https://wa.me/${numeroWhatsApp}?text=${mensajeCodificado}`;
@@ -88,11 +300,11 @@ const Equipos = () => {
       removeFromCart(id);
       return;
     }
-    setCart(prev => prev.map(item => item.id === id ? { ...item, quantity } : item));
+    setCart((prev) => prev.map((item) => (item.id === id ? { ...item, quantity } : item)));
   };
 
   const removeFromCart = (id: number) => {
-    setCart(prev => prev.filter(item => item.id !== id));
+    setCart((prev) => prev.filter((item) => item.id !== id));
   };
 
   const total = cart.reduce((sum, item) => sum + item.price * item.quantity, 0);
@@ -102,16 +314,27 @@ const Equipos = () => {
       <Header />
 
       {/* Hero Section */}
-      <section className="relative py-28 px-6 text-white flex items-center justify-center" style={{ backgroundImage: 'linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)), url(https://images.unsplash.com/photo-1559757148-5c350d0d3c56?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3)', backgroundSize: 'cover', backgroundPosition: 'center' }}>
+      <section
+        className="relative py-28 px-6 text-white flex items-center justify-center"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(0,0,0,0.55), rgba(0,0,0,0.55)), url(https://images.unsplash.com/photo-1559757148-5c350d0d3c56?q=80&w=1600&auto=format&fit=crop&ixlib=rb-4.0.3)',
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+        }}
+      >
         <div className="relative max-w-6xl mx-auto text-center">
           <h1 className="text-4xl md:text-5xl font-bold mb-6">
             Tienda de Equipos <span className="text-blue-200">Ópticos y Médicos</span>
           </h1>
           <p className="text-xl text-blue-100 mb-8 max-w-4xl mx-auto">
-            Productos especializados en óptica, estética, láseres y máquinas de rayos. 
+            Productos especializados en óptica, estética, láseres y máquinas de rayos.
             Tecnología de vanguardia para profesionales de la salud y la ciencia.
           </p>
-          <Button size="lg" className="bg-blue-500 hover:bg-blue-400 text-white">
+          <Button
+            size="lg"
+            className="bg-blue-600 text-white rounded-full px-8 py-6 transition-colors duration-200 hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2"
+          >
             Explorar Productos
           </Button>
         </div>
@@ -130,7 +353,12 @@ const Equipos = () => {
                 key={key}
                 variant={selectedCategory === key ? "default" : "outline"}
                 onClick={() => setSelectedCategory(key)}
-                className={`flex items-center gap-2 ${selectedCategory === key ? 'bg-blue-600 text-white' : 'border-blue-300 text-blue-700 hover:bg-blue-100'}`}
+                className={cn(
+                  "flex items-center gap-2 rounded-full px-5 py-2 transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2",
+                  selectedCategory === key
+                    ? "bg-blue-600 border-blue-600 text-white hover:bg-blue-700"
+                    : "border-blue-200 text-blue-700 hover:bg-blue-100 hover:text-blue-900"
+                )}
               >
                 <Icon className="w-4 h-4" />
                 {label}
@@ -150,23 +378,47 @@ const Equipos = () => {
             </p>
           </div>
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {filteredProducts.map(product => (
-              <Card key={product.id} className="group hover:shadow-lg transition-shadow border-blue-200">
+            {filteredProducts.map((product) => (
+              <Card
+                key={product.id}
+                className="group border border-blue-200 rounded-xl overflow-hidden transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-2xl focus-within:ring-2 focus-within:ring-blue-300 focus-within:ring-offset-2"
+              >
                 <CardHeader className="p-0">
-                  <img src={product.image} alt={product.name} className="w-full h-48 object-cover rounded-t-lg" />
+                  <picture>
+                    {product.image.srcSet && (
+                      <source
+                        srcSet={product.image.srcSet}
+                        type={product.image.type ?? 'image/webp'}
+                        sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                      />
+                    )}
+                    <img
+                      src={product.image.fallback}
+                      loading="lazy"
+                      decoding="async"
+                      alt={product.name}
+                      className="w-full h-52 object-cover transition-transform duration-300 ease-out group-hover:scale-105"
+                    />
+                  </picture>
                 </CardHeader>
                 <CardContent className="p-6">
                   <Badge variant="outline" className="mb-2 border-blue-300 text-blue-700">
-                    {categories.find(c => c.key === product.category)?.label}
+                    {categories.find((c) => c.key === product.category)?.label}
                   </Badge>
                   <CardTitle className="text-blue-800 mb-2">{product.name}</CardTitle>
                   <CardDescription className="text-blue-600 mb-4">{product.description}</CardDescription>
                   <div className="flex items-center justify-between">
                     <span className="text-2xl font-bold text-blue-700">${product.price.toLocaleString()}</span>
-                    <Button onClick={() => { addToCart(product); enviarWhatsApp(product); }} className="bg-blue-600 hover:bg-blue-500 text-white flex items-center">
-                      <Plus className="w-4 h-4 mr-2" />
+                    <Button
+                      onClick={() => {
+                        addToCart(product);
+                        enviarWhatsApp(product);
+                      }}
+                      className="bg-blue-600 text-white flex items-center gap-2 rounded-full px-4 py-2 transition-colors duration-200 hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2"
+                    >
+                      <Plus className="w-4 h-4" />
                       Agregar
-                      <MessageCircle className="w-4 h-4 ml-2" />
+                      <MessageCircle className="w-4 h-4" />
                     </Button>
                   </div>
                 </CardContent>
@@ -194,11 +446,17 @@ const Equipos = () => {
           ) : (
             <div className="grid lg:grid-cols-2 gap-8">
               <div className="space-y-4">
-                {cart.map(item => (
+                {cart.map((item) => (
                   <Card key={item.id} className="border-blue-200">
                     <CardContent className="p-4">
                       <div className="flex items-center gap-4">
-                        <img src={item.image} alt={item.name} className="w-16 h-16 object-cover rounded" />
+                        <img
+                          src={item.image.fallback}
+                          alt={item.name}
+                          loading="lazy"
+                          decoding="async"
+                          className="w-16 h-16 object-cover rounded"
+                        />
                         <div className="flex-1">
                           <h3 className="font-semibold text-blue-800">{item.name}</h3>
                           <p className="text-blue-600">${item.price.toLocaleString()}</p>
@@ -208,7 +466,7 @@ const Equipos = () => {
                             size="sm"
                             variant="outline"
                             onClick={() => updateQuantity(item.id, item.quantity - 1)}
-                            className="border-blue-300 text-blue-700"
+                            className="border-blue-300 text-blue-700 transition-colors duration-200 hover:bg-blue-100 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2"
                           >
                             <Minus className="w-4 h-4" />
                           </Button>
@@ -217,15 +475,11 @@ const Equipos = () => {
                             size="sm"
                             variant="outline"
                             onClick={() => updateQuantity(item.id, item.quantity + 1)}
-                            className="border-blue-300 text-blue-700"
+                            className="border-blue-300 text-blue-700 transition-colors duration-200 hover:bg-blue-100 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2"
                           >
                             <Plus className="w-4 h-4" />
                           </Button>
-                          <Button
-                            size="sm"
-                            variant="destructive"
-                            onClick={() => removeFromCart(item.id)}
-                          >
+                          <Button size="sm" variant="destructive" onClick={() => removeFromCart(item.id)}>
                             <Trash2 className="w-4 h-4" />
                           </Button>
                         </div>
@@ -237,9 +491,11 @@ const Equipos = () => {
               <div className="bg-white p-6 rounded-lg shadow border border-blue-200">
                 <h3 className="text-xl font-bold text-blue-800 mb-4">Resumen del Pedido</h3>
                 <div className="space-y-2 mb-4">
-                  {cart.map(item => (
+                  {cart.map((item) => (
                     <div key={item.id} className="flex justify-between text-blue-700">
-                      <span>{item.name} x{item.quantity}</span>
+                      <span>
+                        {item.name} x{item.quantity}
+                      </span>
                       <span>${(item.price * item.quantity).toLocaleString()}</span>
                     </div>
                   ))}
@@ -250,7 +506,7 @@ const Equipos = () => {
                     <span>${total.toLocaleString()}</span>
                   </div>
                 </div>
-                <Button className="w-full mt-6 bg-blue-600 hover:bg-blue-500 text-white">
+                <Button className="w-full mt-6 bg-blue-600 text-white transition-colors duration-200 hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2">
                   Proceder al Pago
                 </Button>
               </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -101,5 +102,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Reemplazar las tarjetas de Equipos y las galerías de Agrónica, Automática y Biomédica para consumir imágenes optimizadas desde Unsplash en lugar de assets locales.
- Ajustar la lógica de `picture` con tipado opcional para `type` y mantener `srcSet` responsivo en todos los componentes afectados.

## Checklist
- [x] Lint
- [x] Build

------
https://chatgpt.com/codex/tasks/task_e_68eaab6480288323a8150e3eaf6ae23a